### PR TITLE
fix: 캠퍼스 QA 후 수정

### DIFF
--- a/Koin/Core/Extensions/UIImageView+.swift
+++ b/Koin/Core/Extensions/UIImageView+.swift
@@ -5,6 +5,7 @@
 //  Created by 김나훈 on 3/13/24.
 //
 
+import Kingfisher
 import UIKit
 
 // TODO: NS Cache는 앱이 실행되는 동안에만 캐싱. 앱이 종료되면 메모리에서 해제
@@ -36,5 +37,54 @@ extension UIImageView {
                 self.image = downloadedImage
             }
         }.resume()
+    }
+    
+    func loadImageFromBothDiskAndMemory(from URLString: String, radius: Int, transitionTime: TimeInterval? = nil, defaultImage: UIImage? = nil) {
+        let url = URL(string: URLString)
+        let processor = DownsamplingImageProcessor(size: self.bounds.size)
+        |> RoundCornerImageProcessor(cornerRadius: CGFloat(radius))
+        
+        if let transitionTime = transitionTime {
+            self.kf.indicatorType = .activity
+            self.kf.setImage(
+                with: url,
+                placeholder: defaultImage,
+                options: [
+                    .processor(processor),
+                    .scaleFactor(UIScreen.main.scale),
+                    .transition(.fade(transitionTime)),
+                    .cacheOriginalImage
+                ])
+            {
+                result in
+                switch result{
+                case .success:
+                    print("[SUCCESS] Fetching image was succeed with transition")
+                case .failure(let error):
+                    print(error)
+                }
+            }
+        }
+        else {
+            self.kf.indicatorType = .none
+            self.kf.setImage(
+                with: url,
+                placeholder: defaultImage,
+                options: [
+                    .processor(processor),
+                    .scaleFactor(UIScreen.main.scale),
+                    .cacheOriginalImage
+                ])
+            {
+                result in
+                switch result{
+                case .success:
+                    print("[SUCCESS] Fetching image was succeed without transition")
+                case .failure(let error):
+                    print(error)
+                }
+            }
+        }
+        
     }
 }

--- a/Koin/Core/Extensions/UIImageView+.swift
+++ b/Koin/Core/Extensions/UIImageView+.swift
@@ -39,8 +39,8 @@ extension UIImageView {
         }.resume()
     }
     
-    func loadImageFromBothDiskAndMemory(from URLString: String, radius: Int, transitionTime: TimeInterval? = nil, defaultImage: UIImage? = nil) {
-        let url = URL(string: URLString)
+    func loadImageFromBothDiskAndMemory(from urlString: String, radius: Int, transitionTime: TimeInterval? = nil, defaultImage: UIImage? = nil) {
+        let url = URL(string: urlString)
         let processor = DownsamplingImageProcessor(size: self.bounds.size)
         |> RoundCornerImageProcessor(cornerRadius: CGFloat(radius))
         
@@ -55,15 +55,6 @@ extension UIImageView {
                     .transition(.fade(transitionTime)),
                     .cacheOriginalImage
                 ])
-            {
-                result in
-                switch result{
-                case .success:
-                    print("[SUCCESS] Fetching image was succeed with transition")
-                case .failure(let error):
-                    print(error)
-                }
-            }
         }
         else {
             self.kf.indicatorType = .none
@@ -75,15 +66,6 @@ extension UIImageView {
                     .scaleFactor(UIScreen.main.scale),
                     .cacheOriginalImage
                 ])
-            {
-                result in
-                switch result{
-                case .success:
-                    print("[SUCCESS] Fetching image was succeed without transition")
-                case .failure(let error):
-                    print(error)
-                }
-            }
         }
         
     }

--- a/Koin/Data/DTOs/Decodable/Bus/CityBusTimetableDTO.swift
+++ b/Koin/Data/DTOs/Decodable/Bus/CityBusTimetableDTO.swift
@@ -68,13 +68,13 @@ extension CityBusTimetableDTO {
             }
             
             if numberOfAfternoon > numberOfMorning {
-                for idx in lastMorningAndAfternoonIdx + 1..<departInfos.count {
+                for idx in lastMorningAndAfternoonIdx * 2..<departInfos.count {
                     let arrivalInfo = BusArrivalInfo(leftNode: nil, rightNode: departInfos[idx])
                     arrivalInfos.append(arrivalInfo)
                 }
             }
-            else {
-                for idx in lastMorningAndAfternoonIdx + 1..<departInfos.count {
+            else if numberOfAfternoon < numberOfMorning {
+                for idx in lastMorningAndAfternoonIdx..<departInfos.count {
                     let arrivalInfo = BusArrivalInfo(leftNode: departInfos[idx], rightNode: nil)
                     arrivalInfos.append(arrivalInfo)
                 }
@@ -87,8 +87,6 @@ extension CityBusTimetableDTO {
         else {
             busCourseName = "병천 → 터미널"
         }
-        let arrival = self.busInfo.arrivalNode?.rawValue ?? ""
-        
         return BusTimetableInfo(courseName: busCourseName, routeName: "\(busInfo.number?.rawValue ?? 0)번", arrivalInfos: arrivalInfos, updatedAt: updatedAtText)
     }
     

--- a/Koin/Presentation/Dining/DiningViewController.swift
+++ b/Koin/Presentation/Dining/DiningViewController.swift
@@ -295,6 +295,7 @@ extension DiningViewController {
     
     @objc private func navigationButtonTapped() {
         let diningNoticeViewController = DiningNoticeViewController(viewModel: DiningNoticeViewModel(fetchCoopShopListUseCase: DefaultFetchCoopShopListUseCase(diningRepository: DefaultDiningRepository(diningService: DefaultDiningService(), shareService: KakaoShareService()))))
+        diningNoticeViewController.title = "학생식당 정보"
         navigationController?.pushViewController(diningNoticeViewController, animated: true)
     }
     

--- a/Koin/Presentation/Dining/SubViews/CalendarCollectionView/CalendarCollectionViewCell.swift
+++ b/Koin/Presentation/Dining/SubViews/CalendarCollectionView/CalendarCollectionViewCell.swift
@@ -30,7 +30,7 @@ final class CalendarCollectionViewCell: UICollectionViewCell {
         let circleView = UIView()
         let underlineView = UIView()
         let totalView = UIView()
-        circleView.layer.cornerRadius = 15
+        circleView.layer.cornerRadius = 14
         circleView.backgroundColor = UIColor.clear
         circleView.layer.borderColor = UIColor.appColor(.primary500).cgColor
         circleView.layer.borderWidth = 1
@@ -58,7 +58,7 @@ final class CalendarCollectionViewCell: UICollectionViewCell {
     
     private let selectedCircleView: UIView = {
         let circleView = UIView()
-        circleView.layer.cornerRadius = 15
+        circleView.layer.cornerRadius = 14
         circleView.backgroundColor = UIColor.appColor(.primary500)
         
         return circleView

--- a/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionView.swift
+++ b/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionView.swift
@@ -48,6 +48,11 @@ final class DiningCollectionView: UICollectionView, UICollectionViewDataSource, 
             } else {
                 diningList[index].decreaseLike()
             }
+            let indexPath = IndexPath(item: index, section: 0)
+            
+            if let cell = self.cellForItem(at: indexPath) as? DiningCollectionViewCell {
+                cell.updateLikeButtonText(isLiked: isLiked, likeCount: diningList[indexPath.row].likes)
+            }
         }
     }
     
@@ -89,7 +94,6 @@ extension DiningCollectionView {
         cell.likeButtonPublisher.sink { [weak self] in
             guard let self = self else { return }
             self.likeButtonPublisher.send((self.diningList[indexPath.row].id, self.diningList[indexPath.row].isLiked))
-            cell.likeCount = self.diningList[indexPath.row].isLiked ? cell.likeCount-1 : cell.likeCount+1
         }.store(in: &cell.cancellables)
         return cell
     }

--- a/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionView.swift
+++ b/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionView.swift
@@ -48,8 +48,6 @@ final class DiningCollectionView: UICollectionView, UICollectionViewDataSource, 
             } else {
                 diningList[index].decreaseLike()
             }
-            let indexPath = IndexPath(item: index, section: 0)
-            self.reloadItems(at: [indexPath])
         }
     }
     
@@ -91,6 +89,7 @@ extension DiningCollectionView {
         cell.likeButtonPublisher.sink { [weak self] in
             guard let self = self else { return }
             self.likeButtonPublisher.send((self.diningList[indexPath.row].id, self.diningList[indexPath.row].isLiked))
+            cell.likeCount = self.diningList[indexPath.row].isLiked ? cell.likeCount-1 : cell.likeCount+1
         }.store(in: &cell.cancellables)
         return cell
     }

--- a/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionViewCell.swift
+++ b/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionViewCell.swift
@@ -230,10 +230,7 @@ final class DiningCollectionViewCell: UICollectionViewCell {
         menuImageView.layer.cornerRadius = info.imageUrl != nil ? 8 : 0
         menuImageView.clipsToBounds = info.imageUrl != nil ? true: false
         menuImageBackground.isUserInteractionEnabled = info.imageUrl != nil ? true: false
-        if let imageUrl = info.imageUrl {
-            menuImageView.loadImage(from: imageUrl)
-            menuImageView.contentMode = .scaleAspectFill
-        }
+        if let imageUrl = info.imageUrl { menuImageView.loadImageFromBothDiskAndMemory(from: imageUrl, radius: 8, transitionTime: 0.8) }
         else {
             menuImageView.image = UIImage.appImage(asset: .nonMenuImage)
             menuImageView.contentMode = .scaleToFill

--- a/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionViewCell.swift
+++ b/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionViewCell.swift
@@ -16,7 +16,16 @@ final class DiningCollectionViewCell: UICollectionViewCell {
     let shareButtonPublisher = PassthroughSubject<Void, Never>()
     let likeButtonPublisher = PassthroughSubject<Void, Never>()
     var cancellables = Set<AnyCancellable>()
-    
+    var likeCount: Int = 0 {
+        didSet {
+            if oldValue > likeCount {
+                self.updateLikeButtonText(isLiked: false, likeCount: likeCount)
+            }
+            else {
+                self.updateLikeButtonText(isLiked: true, likeCount: likeCount)
+            }
+        }
+    }
     // MARK: - UI Components
     
     private let diningPlaceLabel: UILabel = {
@@ -160,7 +169,7 @@ final class DiningCollectionViewCell: UICollectionViewCell {
         shareButtonPublisher.send(())
     }
     
-    private func updateLikeButtonText(isLiked: Bool, likeCount: Int) {
+    func updateLikeButtonText(isLiked: Bool, likeCount: Int) {
         var configuration = UIButton.Configuration.plain()
         configuration.image = isLiked ? UIImage.appImage(asset: .heartFill) : UIImage.appImage(asset: .heart)
         var text = AttributedString(likeCount == 0 ? "좋아요" : "\(likeCount)")
@@ -175,7 +184,7 @@ final class DiningCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(info: DiningItem) {
-        
+        self.likeCount = info.likes
         diningPlaceLabel.text = info.place.rawValue
         updateLikeButtonText(isLiked: info.isLiked, likeCount: info.likes)
         

--- a/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionViewCell.swift
+++ b/Koin/Presentation/Dining/SubViews/DiningCollectionView/DiningCollectionViewCell.swift
@@ -16,16 +16,7 @@ final class DiningCollectionViewCell: UICollectionViewCell {
     let shareButtonPublisher = PassthroughSubject<Void, Never>()
     let likeButtonPublisher = PassthroughSubject<Void, Never>()
     var cancellables = Set<AnyCancellable>()
-    var likeCount: Int = 0 {
-        didSet {
-            if oldValue > likeCount {
-                self.updateLikeButtonText(isLiked: false, likeCount: likeCount)
-            }
-            else {
-                self.updateLikeButtonText(isLiked: true, likeCount: likeCount)
-            }
-        }
-    }
+    
     // MARK: - UI Components
     
     private let diningPlaceLabel: UILabel = {
@@ -184,7 +175,6 @@ final class DiningCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(info: DiningItem) {
-        self.likeCount = info.likes
         diningPlaceLabel.text = info.place.rawValue
         updateLikeButtonText(isLiked: info.isLiked, likeCount: info.likes)
         

--- a/Koin/Presentation/Dining/SubViews/DiningNotiContentViewController.swift
+++ b/Koin/Presentation/Dining/SubViews/DiningNotiContentViewController.swift
@@ -38,7 +38,7 @@ final class DiningNotiContentViewController: UIViewController {
     
     private let soldOutSwitch = UISwitch().then {
         $0.onTintColor = UIColor.appColor(.primary500)
-        $0.transform = CGAffineTransformMakeScale(0.9, 0.75)
+        $0.transform = CGAffineTransformMakeScale(0.8, 0.8)
     }
     
     private let imageUploadNotiLabel = UILabel().then {
@@ -48,7 +48,7 @@ final class DiningNotiContentViewController: UIViewController {
     
     private let imageUploadSwitch = UISwitch().then {
         $0.onTintColor = UIColor.appColor(.primary500)
-        $0.transform = CGAffineTransformMakeScale(0.9, 0.75)
+        $0.transform = CGAffineTransformMakeScale(0.8, 0.8)
     }
     
     private let notiShortcutButton = UIButton().then {

--- a/Koin/Presentation/DiningNotice/DiningNoticeViewController.swift
+++ b/Koin/Presentation/DiningNotice/DiningNoticeViewController.swift
@@ -8,7 +8,7 @@
 import Combine
 import UIKit
 
-final class DiningNoticeViewController: UIViewController {
+final class DiningNoticeViewController: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: - Properties
     
@@ -22,6 +22,12 @@ final class DiningNoticeViewController: UIViewController {
         let label = UILabel()
         label.text = "학생식당 정보"
         return label
+    }()
+    
+    private let backButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage.appImage(asset: .arrowBack), for: .normal)
+        return button
     }()
 
     private let diningGuideLabel: UILabel = {
@@ -105,16 +111,19 @@ final class DiningNoticeViewController: UIViewController {
         configureView()
         bind()
         inputSubject.send(.fetchCoopShopList)
+        backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(true)
-        setUpOriginalNavigationBar()
+        navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
-        setUpNavigationBar()
+        navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 
     // MARK: - Bind
@@ -157,49 +166,25 @@ extension DiningNoticeViewController {
 }
 
 extension DiningNoticeViewController {
-    
-    private func setUpNavigationBar() {
-        let appearance = UINavigationBarAppearance()
-        appearance.shadowColor = .white
-        appearance.backgroundColor = .white
-        let backBtnAppearance = UIBarButtonItemAppearance()
-        backBtnAppearance.normal.backgroundImage = UIImage.appImage(asset: .arrowBack)?.withTintColor(.black)
-        appearance.backButtonAppearance = backBtnAppearance
-        let font = UIFont.appFont(.pretendardMedium, size: 20)
-        let titleAttribute = [
-            NSAttributedString.Key.font: font,
-            NSAttributedString.Key.foregroundColor: UIColor.black
-        ]
-        appearance.titleTextAttributes = titleAttribute
-        self.navigationController?.navigationBar.standardAppearance = appearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = appearance
-    }
-    
-    private func setUpOriginalNavigationBar() {
-        let appearance = UINavigationBarAppearance()
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = .appColor(.primary500)
-        
-        let font = UIFont.appFont(.pretendardMedium, size: 20)
-        let titleAttribute = [
-            NSAttributedString.Key.font: font,
-            NSAttributedString.Key.foregroundColor: UIColor.white
-        ]
-        appearance.titleTextAttributes = titleAttribute
-        
-        self.navigationController?.navigationBar.standardAppearance = appearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = appearance
-    }
-    
     private func setUpLayOuts() {
-        [navigationTitle, updateDateLabel, diningGuideLabel, placeGuideLabel, placeTextLabel, phoneGuideLabel, phoneTextLabel, separateView, weekdayTimeLabel, weekdayTimeCollectionView, weekendTimeLabel, weekendTimeCollectionView].forEach {
+        [backButton, navigationTitle, updateDateLabel, diningGuideLabel, placeGuideLabel, placeTextLabel, phoneGuideLabel, phoneTextLabel, separateView, weekdayTimeLabel, weekdayTimeCollectionView, weekendTimeLabel, weekendTimeCollectionView].forEach {
             self.view.addSubview($0)
         }
     }
     
     private func setUpConstraints() {
+        backButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            make.leading.equalTo(view.snp.leading).offset(24)
+            make.width.equalTo(24)
+            make.height.equalTo(24)
+        }
+        navigationTitle.snp.makeConstraints { make in
+            make.centerY.equalTo(backButton.snp.centerY)
+            make.centerX.equalTo(view.snp.centerX)
+        }
         diningGuideLabel.snp.makeConstraints { make in
-            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).offset(20)
+            make.top.equalTo(backButton.snp.bottom).offset(28)
             make.leading.equalTo(updateDateLabel.snp.leading)
             make.height.equalTo(32)
         }

--- a/Koin/Presentation/DiningNotice/DiningNoticeViewController.swift
+++ b/Koin/Presentation/DiningNotice/DiningNoticeViewController.swift
@@ -23,13 +23,7 @@ final class DiningNoticeViewController: UIViewController {
         label.text = "학생식당 정보"
         return label
     }()
-    
-    private let backButton: UIButton = {
-        let button = UIButton()
-        button.setImage(UIImage.appImage(asset: .arrowBack), for: .normal)
-        return button
-    }()
-    
+
     private let diningGuideLabel: UILabel = {
         let label = UILabel()
         return label
@@ -111,17 +105,16 @@ final class DiningNoticeViewController: UIViewController {
         configureView()
         bind()
         inputSubject.send(.fetchCoopShopList)
-        backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(true)
-        navigationController?.navigationBar.isHidden = false
+        setUpOriginalNavigationBar()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
-        navigationController?.navigationBar.isHidden = true
+        setUpNavigationBar()
     }
 
     // MARK: - Bind
@@ -165,25 +158,48 @@ extension DiningNoticeViewController {
 
 extension DiningNoticeViewController {
     
+    private func setUpNavigationBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.shadowColor = .white
+        appearance.backgroundColor = .white
+        let backBtnAppearance = UIBarButtonItemAppearance()
+        backBtnAppearance.normal.backgroundImage = UIImage.appImage(asset: .arrowBack)?.withTintColor(.black)
+        appearance.backButtonAppearance = backBtnAppearance
+        let font = UIFont.appFont(.pretendardMedium, size: 20)
+        let titleAttribute = [
+            NSAttributedString.Key.font: font,
+            NSAttributedString.Key.foregroundColor: UIColor.black
+        ]
+        appearance.titleTextAttributes = titleAttribute
+        self.navigationController?.navigationBar.standardAppearance = appearance
+        self.navigationController?.navigationBar.scrollEdgeAppearance = appearance
+    }
+    
+    private func setUpOriginalNavigationBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .appColor(.primary500)
+        
+        let font = UIFont.appFont(.pretendardMedium, size: 20)
+        let titleAttribute = [
+            NSAttributedString.Key.font: font,
+            NSAttributedString.Key.foregroundColor: UIColor.white
+        ]
+        appearance.titleTextAttributes = titleAttribute
+        
+        self.navigationController?.navigationBar.standardAppearance = appearance
+        self.navigationController?.navigationBar.scrollEdgeAppearance = appearance
+    }
+    
     private func setUpLayOuts() {
-        [backButton, navigationTitle, updateDateLabel, diningGuideLabel, placeGuideLabel, placeTextLabel, phoneGuideLabel, phoneTextLabel, separateView, weekdayTimeLabel, weekdayTimeCollectionView, weekendTimeLabel, weekendTimeCollectionView].forEach {
+        [navigationTitle, updateDateLabel, diningGuideLabel, placeGuideLabel, placeTextLabel, phoneGuideLabel, phoneTextLabel, separateView, weekdayTimeLabel, weekdayTimeCollectionView, weekendTimeLabel, weekendTimeCollectionView].forEach {
             self.view.addSubview($0)
         }
     }
     
     private func setUpConstraints() {
-        backButton.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            make.leading.equalTo(view.snp.leading).offset(24)
-            make.width.equalTo(24)
-            make.height.equalTo(24)
-        }
-        navigationTitle.snp.makeConstraints { make in
-            make.centerY.equalTo(backButton.snp.centerY)
-            make.centerX.equalTo(view.snp.centerX)
-        }
         diningGuideLabel.snp.makeConstraints { make in
-            make.top.equalTo(backButton.snp.bottom).offset(28)
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).offset(20)
             make.leading.equalTo(updateDateLabel.snp.leading)
             make.height.equalTo(32)
         }

--- a/Koin/Presentation/Home/HomeViewController.swift
+++ b/Koin/Presentation/Home/HomeViewController.swift
@@ -92,7 +92,6 @@ final class HomeViewController: UIViewController, CollectionViewDelegate {
     
     private let menuLabel: UILabel = {
         let label = UILabel()
-        label.text = "오늘식단"
         label.textColor = UIColor.appColor(.primary500)
         label.font = UIFont.appFont(.pretendardBold, size: 15)
         return label
@@ -208,8 +207,8 @@ final class HomeViewController: UIViewController, CollectionViewDelegate {
         let outputSubject = viewModel.transform(with: inputSubject.eraseToAnyPublisher())
         outputSubject.receive(on: DispatchQueue.main).sink { [weak self] output in
             switch output {
-            case let .updateDining(diningItem, diningType, diningDate):
-                self?.updateDining(item: diningItem, type: diningType, date: diningDate)
+            case let .updateDining(diningItem, diningType, isToday):
+                self?.updateDining(item: diningItem, type: diningType, isToday: isToday)
             case let .putImage(response):
                 self?.putImage(data: response)
             case let .updateBus(response):
@@ -377,10 +376,13 @@ extension HomeViewController {
         inputSubject.send(.logEvent(EventParameter.EventLabel.Campus.mainBus, .click, "버스"))
     }
     
-    private func updateDining(item: DiningItem?, type: DiningType, date: Date) {
+    private func updateDining(item: DiningItem?, type: DiningType, isToday: Bool) {
         menuBackgroundView.updateDining(item, type)
-        if date.formatDateToYYMMDD() != Date().formatDateToYYMMDD() {
-            self.menuLabel.text = "내일식단"
+        if isToday {
+            self.menuLabel.text = "오늘 식단"
+        }
+        else {
+            self.menuLabel.text = "내일 식단"
         }
     }
     

--- a/Koin/Presentation/Home/HomeViewController.swift
+++ b/Koin/Presentation/Home/HomeViewController.swift
@@ -92,7 +92,7 @@ final class HomeViewController: UIViewController, CollectionViewDelegate {
     
     private let menuLabel: UILabel = {
         let label = UILabel()
-        label.text = "식단"
+        label.text = "오늘식단"
         label.textColor = UIColor.appColor(.primary500)
         label.font = UIFont.appFont(.pretendardBold, size: 15)
         return label
@@ -208,8 +208,8 @@ final class HomeViewController: UIViewController, CollectionViewDelegate {
         let outputSubject = viewModel.transform(with: inputSubject.eraseToAnyPublisher())
         outputSubject.receive(on: DispatchQueue.main).sink { [weak self] output in
             switch output {
-            case let .updateDining(diningItem, diningType):
-                self?.updateDining(item: diningItem, type: diningType)
+            case let .updateDining(diningItem, diningType, diningDate):
+                self?.updateDining(item: diningItem, type: diningType, date: diningDate)
             case let .putImage(response):
                 self?.putImage(data: response)
             case let .updateBus(response):
@@ -377,8 +377,11 @@ extension HomeViewController {
         inputSubject.send(.logEvent(EventParameter.EventLabel.Campus.mainBus, .click, "버스"))
     }
     
-    private func updateDining(item: DiningItem?, type: DiningType) {
+    private func updateDining(item: DiningItem?, type: DiningType, date: Date) {
         menuBackgroundView.updateDining(item, type)
+        if date.formatDateToYYMMDD() != Date().formatDateToYYMMDD() {
+            self.menuLabel.text = "내일식단"
+        }
     }
     
     private func putImage(data: ShopCategoryDTO) {

--- a/Koin/Presentation/Home/HomeViewModel.swift
+++ b/Koin/Presentation/Home/HomeViewModel.swift
@@ -23,7 +23,7 @@ final class HomeViewModel: ViewModelProtocol {
     // MARK: - Output
     
     enum Output {
-        case updateDining(DiningItem?, DiningType)
+        case updateDining(DiningItem?, DiningType, Date)
         case updateBus(BusDTO)
         case putImage(ShopCategoryDTO)
         case moveBusItem
@@ -106,7 +106,7 @@ extension HomeViewModel {
             }
         } receiveValue: { [weak self] response in
             let result = response.filter { $0.place == diningPlace }.first
-            self?.outputSubject.send(.updateDining(result, dateInfo.diningType))
+            self?.outputSubject.send(.updateDining(result, dateInfo.diningType, dateInfo.date))
         }.store(in: &subscriptions)
     }
     

--- a/Koin/Presentation/Home/HomeViewModel.swift
+++ b/Koin/Presentation/Home/HomeViewModel.swift
@@ -23,7 +23,7 @@ final class HomeViewModel: ViewModelProtocol {
     // MARK: - Output
     
     enum Output {
-        case updateDining(DiningItem?, DiningType, Date)
+        case updateDining(DiningItem?, DiningType, Bool)
         case updateBus(BusDTO)
         case putImage(ShopCategoryDTO)
         case moveBusItem
@@ -106,7 +106,7 @@ extension HomeViewModel {
             }
         } receiveValue: { [weak self] response in
             let result = response.filter { $0.place == diningPlace }.first
-            self?.outputSubject.send(.updateDining(result, dateInfo.diningType, dateInfo.date))
+            self?.outputSubject.send(.updateDining(result, dateInfo.diningType, dateInfo.date.formatDateToYYMMDD() == Date().formatDateToYYMMDD()))
         }.store(in: &subscriptions)
     }
     

--- a/Koin/Presentation/Home/SubViews/BusCollectionView/BusCollectionViewCell.swift
+++ b/Koin/Presentation/Home/SubViews/BusCollectionView/BusCollectionViewCell.swift
@@ -16,10 +16,15 @@ final class BusCollectionViewCell: UICollectionViewCell {
     var cancellables = Set<AnyCancellable>()
     // MARK: - UI Components
     
+    private let wrapperView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
     private let busLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.appFont(.pretendardBold, size: 12)
-        label.backgroundColor = UIColor.appColor(.bus1)
         label.textColor = UIColor.appColor(.neutral0)
         label.textAlignment = .center
         return label
@@ -119,7 +124,7 @@ extension BusCollectionViewCell {
     func configure(busType: BusType, redirectedText: String, colorAsset: SceneColorAsset) {
         busLabel.text = busType.koreanDescription
         redirectedLabel.text = redirectedText
-        busLabel.backgroundColor = UIColor.appColor(colorAsset)
+        self.contentView.backgroundColor = .appColor(colorAsset)
     }
         
     func getBusEnumType(busType: BusType) -> BusType {
@@ -199,8 +204,11 @@ extension BusCollectionViewCell {
 
 extension BusCollectionViewCell {
     private func setUpLayouts() {
-        [busLabel, timeLabel, startAreaLabel, exchangeAreaButton, endAreaLabel, startTimeLabel, redirectedButton].forEach {
+        [busLabel, wrapperView].forEach {
             contentView.addSubview($0)
+        }
+        [timeLabel, startAreaLabel, exchangeAreaButton, endAreaLabel, startTimeLabel, redirectedButton].forEach {
+            wrapperView.addSubview($0)
         }
         [redirectedLabel, arrowImage].forEach {
             redirectedButton.addSubview($0)
@@ -210,11 +218,15 @@ extension BusCollectionViewCell {
     private func setUpConstraints() {
         busLabel.snp.makeConstraints { make in
             make.top.equalTo(self.snp.top)
-            make.width.equalTo(self.snp.width)
-            make.height.equalTo(30)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(35)
+        }
+        wrapperView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(35)
+            make.leading.trailing.bottom.equalToSuperview()
         }
         timeLabel.snp.makeConstraints { make in
-            make.top.equalTo(busLabel.snp.bottom).offset(15)
+            make.top.equalToSuperview().offset(15)
             make.centerX.equalTo(self.snp.centerX)
             make.height.equalTo(16)
         }
@@ -259,6 +271,8 @@ extension BusCollectionViewCell {
     private func setUpBorder() {
         self.layer.borderWidth = 1.0
         self.layer.borderColor = UIColor.appColor(.neutral500).withAlphaComponent(0.2).cgColor
+        self.layer.cornerRadius = 8
+        self.contentView.layer.cornerRadius = 8
     }
     
     private func configureView() {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1 

## 📝작업 내용

- 식단 상세 뷰에서 운영정보 페이지로 넘어갈 때 네비게이션 바 깨짐 해결
 - 식단 페이지 좋아요 눌렀을 시 깜빡거림
 - HomeVC에서 버스카드 명세대로 radius 수정
 - 식단 상세 달력 콜렉션뷰에서 선택하는 indicator의 radius 수정
 - 바텀 시트의 스위치 모양 수정
 - diningVC에 식단을 오늘 식단, 내일 식단 구분지어 표시하는 것으로 수정
 - 시내버스 데이터 중복되어 나타나는 버그 수정
 - 이미지 캐싱 로직을 Kingfisher을 사용하여 수정 (diningVC의 사진에만 적용)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 
